### PR TITLE
[FIX] typo for file name and replace `flex: 1` with `flex-grow: 1`

### DIFF
--- a/snippets/last-item-with-all-available-height.md
+++ b/snippets/last-item-with-all-available-height.md
@@ -29,7 +29,7 @@ body {
 
 .container > div:last-child {
   background-color: #333;
-  flex: 1;
+  flex-grow: 1;
 }
 ```
 


### PR DESCRIPTION
1. typo for file name
2. replace `flex:1` with `flex-grow:1` in snippet