### PR TITLE
Update system-font-stack.md

### DIFF
--- a/snippets/system-font-stack.md
+++ b/snippets/system-font-stack.md
@@ -28,11 +28,12 @@ falls back to the next if it cannot find the font (on the system or defined in C
 2. `BlinkMacSystemFont` is San Francisco, used on macOS Chrome
 3. `Segoe UI` is used on Windows 10
 4. `Roboto` is used on Android
-5. `Oxygen-Sans` is used on GNU+Linux
-6. `Ubuntu` is used on Linux
-7. `"Helvetica Neue"` and `Helvetica` is used on macOS 10.10 and below (wrapped in quotes because it has a space)
-8. `Arial` is a font widely supported by all operating systems
-9. `sans-serif` is the fallback sans-serif font if none of the other fonts are supported
+5. `Oxygen-Sans` is used on Linux with KDE
+6. `Ubuntu` is used on Ubuntu (all variants)
+7. `Cantarell` is used on Linux with GNOME Shell
+8. `"Helvetica Neue"` and `Helvetica` is used on macOS 10.10 and below (wrapped in quotes because it has a space)
+9. `Arial` is a font widely supported by all operating systems
+10. `sans-serif` is the fallback sans-serif font if none of the other fonts are supported
 
 #### Browser support
 


### PR DESCRIPTION
- Missing explanation added to `Cantarell`
- Fonts used on "Linux" explained