### PR TITLE
[FIX] use darker color to have a clear contrast

### DIFF
--- a/snippets/zebra-striped-list.md
+++ b/snippets/zebra-striped-list.md
@@ -18,7 +18,7 @@ Creates a striped list with alternating background colors, which is useful for d
 
 ```css
 li:nth-child(odd) {
-  background-color: #eee;
+  background-color: #ddd;
 }
 ```
 


### PR DESCRIPTION
I just saw the `Zebra striped list` snipped in the `30 Seconds of Knowledge` Chrome Extension and couldn't clearly see a contrast, because the background-color is too light.

On bad screens it's probably not visible at all, we should make it a bit darker.

![IMG_4342](https://user-images.githubusercontent.com/3001431/59915549-29eef780-941d-11e9-898b-3e36a682988c.JPG)
