### PR TITLE
[FIX] Fixing a typo in the title of the hamburger button

### DIFF
--- a/snippets/hamburger-button.md
+++ b/snippets/hamburger-button.md
@@ -1,5 +1,5 @@
 ---
-title: Hamburguer Button
+title: Hamburger Button
 tags: interactivity,beginner
 ---
 


### PR DESCRIPTION
The hamburger button page was titled "Hamburguer Button", so I corrected it to "Hamburger Button" (no `uer` at the end of hamburger, just `er`)

<!--- Add the prefix [FIX] or [FEATURE] to the title -->
