### PR TITLE
Fixed broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Want to contribute?
 
 * If you want to help us improve, take a minute to read the [Contribution Guidelines](/CONTRIBUTING.md) first.
-* Use the [Snippet Template](/snippet_template.md) to add new snippets to the collection.
+* Use the [Snippet Template](/snippet-template.md) to add new snippets to the collection.
 * If you find a problem with a specific snippet, please [open an issue](https://github.com/30-seconds/30-seconds-of-css/issues/new).
 * If you find a problem with the website, please [report it in the web repository](https://github.com/30-seconds/30-seconds-web/issues/new).
 


### PR DESCRIPTION
The second point in "Want to Contribute", the link to snippet template was broken. as it was linking to /snippet_template.md. I changed it to /snippet-template.md and it works now.