### PR TITLE
The container 'horizontal-snap' will overflow on mobile phone.

### DIFF
--- a/snippets/horizontal-scroll-snap.md
+++ b/snippets/horizontal-scroll-snap.md
@@ -33,7 +33,6 @@ Creates a horizontally scrollable container that will snap on elements when scro
   gap: 1rem;
   height: calc(180px + 1rem);
   padding: 1rem;
-  width: 480px;
   overflow-y: auto;
   overscroll-behavior-x: contain;
   scroll-snap-type: x mandatory;

--- a/snippets/horizontal-scroll-snap.md
+++ b/snippets/horizontal-scroll-snap.md
@@ -33,6 +33,7 @@ Creates a horizontally scrollable container that will snap on elements when scro
   gap: 1rem;
   height: calc(180px + 1rem);
   padding: 1rem;
+  max-width: 480px;
   overflow-y: auto;
   overscroll-behavior-x: contain;
   scroll-snap-type: x mandatory;


### PR DESCRIPTION
The container 'horizontal-snap' will overflow on mobile phone. Cause by the fixed width.